### PR TITLE
156655280 post turn

### DIFF
--- a/containers/Playground/Table/index.js
+++ b/containers/Playground/Table/index.js
@@ -213,18 +213,20 @@ export default class Table extends Component {
 
 	finishTurn() {
 	 	gameState = {
-		        supply: this.state.supply,
-						trash: this.state.trash,
-						attack_stack: this.state.attackStack,
-						draw: this.state.draw,
-						discard: this.state.discard,
-		        turn: {
-		          coins: this.state.coins,
-		          cards_played: this.state.playarea,
-		          cards_gained: this.state.cardsGained,
-		          cards_trashed: this.state.cardsTrashed
-		          }
-		        }
+      supply: this.state.supply,
+			trash: this.state.trash,
+			attack_stack: this.state.attackStack,
+			deck: {
+				draw: this.state.draw,
+				discard: this.state.discard
+			},
+      turn: {
+        coins: this.state.coins,
+        cards_played: this.state.playarea,
+        cards_gained: this.state.cardsGained,
+        cards_trashed: this.state.cardsTrashed
+        }
+    }
 		postTurn(this.state.gameId, gameState)
 			.then(alert('Turn completed'))
 	}

--- a/containers/Playground/Table/index.js
+++ b/containers/Playground/Table/index.js
@@ -17,7 +17,7 @@ import TurnDetail from '../../../components/TurnDetail';
 import { images } from '@assets/images'
 import PopupDialog from '../../../components/PopupDialog'
 import dominionCards from '../../../game-utilities/dominion'
-import { getGameState } from '../../../game-utilities/services'
+import { getGameState, postTurn } from '../../../game-utilities/services'
 
 export default class Table extends Component {
   constructor() {
@@ -32,7 +32,8 @@ export default class Table extends Component {
 			actions: 1,
 			buys: 1,
 			coins: 0,
-			cardsBought: [],
+			cardsGained: [],
+			cardsTrashed: [],
 			competitors: [],
 			attackStack: {},
 			currentPlayer: null,
@@ -143,10 +144,10 @@ export default class Table extends Component {
 		if (this.canBuyCard(card)) {
 			let supply = this.state.supply
 			supply[card]--
-			let cardsBought = [...this.state.cardsBought, card]
+			let cardsGained = [...this.state.cardsGained, card]
 			this.setState({
 				coins: this.state.coins - dominionCards[card]['cost'],
-				cardsBought: cardsBought,
+				cardsGained: cardsGained,
 				supply: supply,
 				buys: this.state.buys - 1,
 				hasBought: true
@@ -211,7 +212,21 @@ export default class Table extends Component {
 	}
 
 	finishTurn() {
-		alert("Turn Completed")
+	 	gameState = {
+		        supply: this.state.supply,
+						trash: this.state.trash,
+						attack_stack: this.state.attackStack,
+						draw: this.state.draw,
+						discard: this.state.discard,
+		        turn: {
+		          coins: this.state.coins,
+		          cards_played: this.state.playarea,
+		          cards_gained: this.state.cardsGained,
+		          cards_trashed: this.state.cardsTrashed
+		          }
+		        }
+		postTurn(this.state.gameId, gameState)
+			.then(alert('Turn completed'))
 	}
 
   render() {

--- a/containers/Playground/Table/index.js
+++ b/containers/Playground/Table/index.js
@@ -218,7 +218,12 @@ export default class Table extends Component {
 			attack_stack: this.state.attackStack,
 			deck: {
 				draw: this.state.draw,
-				discard: this.state.discard
+				discard: [
+					...this.state.discard,
+					...this.state.playarea,
+					...this.state.hand,
+					...this.staet.cardsGained
+				]
 			},
       turn: {
         coins: this.state.coins,

--- a/game-utilities/dominion.js
+++ b/game-utilities/dominion.js
@@ -56,10 +56,7 @@ export default dominonCards = {
 	'smithy': {
 		'type': 'action',
 		'action': (state) => {
-			let newActions = actions(state.actions, -1)
-			let draw = drawCards(3, state.draw, state.hand)
-			let resultingState = _.merge(draw, newActions)
-			return resultingState
+			return drawCards(3, state.draw, state.hand)
 		},
 		'cost': 4
 	},

--- a/game-utilities/dominion.js
+++ b/game-utilities/dominion.js
@@ -54,9 +54,12 @@ export default dominonCards = {
 		'cost': 5
 	},
 	'smithy': {
-	'type': 'action',
-	 'action': (state) => {
-			return drawCards(3, state.draw, state.hand)
+		'type': 'action',
+		'action': (state) => {
+			let newActions = actions(state.actions, -1)
+			let draw = drawCards(3, state.draw, state.hand)
+			let resultingState = _.merge(draw, newActions)
+			return resultingState
 		},
 		'cost': 4
 	},

--- a/game-utilities/services.js
+++ b/game-utilities/services.js
@@ -20,11 +20,25 @@ const errorLog = (error) => {
 	console.error({ error })
 }
 
-const getGameState = (gameID) => {
-	return fetch(`${baseURL}/api/v1/games/${gameID}`)
+const getGameState = (gameId) => {
+	return fetch(`${baseURL}/api/v1/games/${gameId}`)
+		.then(handleResponse)
+		.catch(errorLog)
+}
+
+const postConfig = (gameState) => {
+	return {
+      method: 'POST',
+      headers: {'Content-Type': "application/json"},
+			body: JSON.stringify(gameState)
+    }
+}
+
+const postTurn = (gameId, gameState) => {
+	return fetch(`${baseURL}/api/v1/games/${gameId}/turns`, postConfig(gameState))
 		.then(handleResponse)
 		.catch(errorLog)
 }
 
 
-module.exports = { getGameState }
+module.exports = { getGameState, postTurn }


### PR DESCRIPTION
- Adds postTurn method
- Post turn occurs when buys are completed
- Confirmed that backend is getting correct parameters in the heroku log
```
Parameters: {
"supply"=>{"copper"=>40, "curse"=>10, "silver"=>30, "gold"=>30, "estate"=>10, "duchy"=>10, "province"=>10, "merchant"=>10, "festival"=>10, "artisan"=>10, "bureaucrat"=>10, "throne room"=>10, "library"=>10, "gardens"=>10, "council room"=>10, "militia"=>10, "bandit"=>10}, 

"trash"=>[], 

"attack_stack"=>{"1"=>[], "2"=>[]},
 
"deck"=>{"draw"=>[], "discard"=>["copper", "gold", "gold", "smithy", "festival", "laboratory", "copper", "copper", "copper", "copper", "copper", "estate", "estate", "copper", "estate"]}, 

"turn"=>{"coins"=>9, "cards_played"=>["copper", "gold", "gold", "smithy", "festival", "laboratory"], "cards_gained"=>[], "cards_trashed"=>[]}, "id"=>"3"}
```